### PR TITLE
Removendo a Guava

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ Para contribuir, leia [CONTRIBUTING](CONTRIBUTING.md).
 * [Fractal Tecnologia](http://fractaltecnologia.com.br) - matriz
 ### Pernambuco (PE)
 * [Capyba](https://capyba.com/)
-* [Guava](https://guavasoftware.com/)
 * [Incognia](https://www.incognia.com/) - matriz
 * [Skyhub](https://skyhub.com.br/)
 ### Piauí (PI)

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Para contribuir, leia [CONTRIBUTING](CONTRIBUTING.md).
 * [Reserva](https://www.usereserva.com/)
 * [Rupee](https://www.rupee.com.br/)
 * [SkyHub](https://skyhub.com.br/) - matriz
-*  [Unimed Federação do Estado do Rio de Janeiro](https://www.unimedrj.coop.br/)
+* [Unimed Federação do Estado do Rio de Janeiro](https://www.unimedrj.coop.br/)
 * [Webedia/Tudogostoso](https://www.tudogostoso.com.br/)
 * [Wpensar](https://wpensar.com.br/)
 * [XL Solutions](http://www.xlsol.com/)
@@ -166,6 +166,7 @@ Para contribuir, leia [CONTRIBUTING](CONTRIBUTING.md).
 * [Knowbe4](https://knowbe4.com)
 * [Kria](https://www.kria.vc/)
 * [Liber Capital](https://libercapital.com.br)
+* [Linkana](https://www.linkana.com/)
 * [Locaweb](https://locaweb.com.br)
 * [Luztr](http://www.luztr.com/)
 * [Magnetis](https://magnetis.com.br)
@@ -190,6 +191,7 @@ Para contribuir, leia [CONTRIBUTING](CONTRIBUTING.md).
 * [Vindi](https://vindi.com.br/)
 * [Worldpackers](https://worldpackers.com)
 * [Zag](https://www.zagapp.com.br)
+* [Zazos](https://www.zazos.com/)
 
 ---
 


### PR DESCRIPTION
Infelizmente a Guava foi adquirida pela Vtex que não utiliza Ruby.

A Guava foi a maior e melhor consultoria em linha reta do Brasil e foi responsável pela criação do Tropical.rb