### PR TITLE
Atualiza Dev4Labs para Devlabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Para contribuir, leia [CONTRIBUTING](CONTRIBUTING.md).
 * [Cilia](https://cilia.com.br/)
 * [Codeminer 42](http://www.codeminer42.com/)
 * [Cogni](https://cogni.group/)
-* [Dev4Labs](https://www.dev4web.com.br/)
+* [Devlabs](http://devlabs.digital/)
 * [EasyCrédito](https://easycredito.me/) - matriz
 * [Gado e Cia](http://www.gadoecia.com.br/)
 * [Secretaria de Educação e Esporte do Estado de Goiás](https://www.seduce.go.gov.br/)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Para contribuir, leia [CONTRIBUTING](CONTRIBUTING.md).
 * [Cilia](https://cilia.com.br/)
 * [Codeminer 42](http://www.codeminer42.com/)
 * [Cogni](https://cogni.group/)
-* [Devlabs](http://devlabs.digital/)
+* [Devlabs](https://devlabs.digital/)
 * [EasyCrédito](https://easycredito.me/) - matriz
 * [Gado e Cia](http://www.gadoecia.com.br/)
 * [Secretaria de Educação e Esporte do Estado de Goiás](https://www.seduce.go.gov.br/)


### PR DESCRIPTION
A empresa Dev4Labs foi renomeada para Devlabs.
Esse PR faz a atualização do nome e do link para o site da empresa.