### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,6 @@ Para contribuir, leia [CONTRIBUTING](CONTRIBUTING.md).
 * [Anuncie Ribeirão](https://www.anuncieribeirao.com/)
 * [App Eu Quero (API)](https://appeuquero.com/home/)
 * [AppGas](https://appgas.com/)
-* [AutoSeg](https://autoseg.com/)
 * [Bicos](https://www.bicos.com.br/)
 * [Bio Ritmo](https://www.bioritmo.com.br) / [Smart Fit](https://www.smartfit.com.br) - matriz
 * [Bionexo](https://bionexo.com)


### PR DESCRIPTION
# Breve descrição
Esse commit remove a empresa "Autoseg" da lista.

# Contexto
Salvo engano, quem tinha adiciona a empresa "Autoseg" tinha sido eu mesmo. Atualmente, dando uma breve fuçada no LinkedIn vi que com o tempo a "Autoseg" mudou seu nome para "Turia", e após isso parece que ouve uma junção da "Turia" com a "Magalu Cloud". Não sei dizer qual a stack atual da "Magalu Cloud", mas acho que não usam Ruby.

# Refs
- [Site da Turia](https://www.turia.com.br/)
- [Post da junção das empresas citadas](https://www.linkedin.com/posts/autoseg_turia-magalucloud-inovaaexaeto-activity-7168705681343164417-7WZK?utm_source=share&utm_medium=member_desktop)